### PR TITLE
Python 3 Support

### DIFF
--- a/pyshoco.c
+++ b/pyshoco.c
@@ -51,14 +51,14 @@ static PyObject *pyshoco_compress(PyObject *self, PyObject *args) {
     size_t outsize = insize*2+1;
     char out[outsize];
     outsize = shoco_compress(in, insize, out, outsize);
-    return Py_BuildValue("s#", out, outsize);
+    return Py_BuildValue("y#", out, outsize);
 }
 
 static PyObject *pyshoco_decompress(PyObject *self, PyObject *args) {
     const char *in;
     size_t insize;
 
-    if (!PyArg_ParseTuple(args, "s#", &in, &insize))
+    if (!PyArg_ParseTuple(args, "y#", &in, &insize))
         return NULL;
     
     size_t outsize = insize*2+1;

--- a/pyshoco.c
+++ b/pyshoco.c
@@ -32,12 +32,16 @@ PyMODINIT_FUNC PyInit_pyshoco(void)
     return PyModule_Create(&shocomodule);
 }
 
+const char *bytesFormat = "y#";
+
 #else
     
 PyMODINIT_FUNC initpyshoco(void)
 {
     (void) Py_InitModule("pyshoco", ShocoMethods);
 }
+
+const char *bytesFormat = "s#";
 
 #endif
 
@@ -51,14 +55,14 @@ static PyObject *pyshoco_compress(PyObject *self, PyObject *args) {
     size_t outsize = insize*2+1;
     char out[outsize];
     outsize = shoco_compress(in, insize, out, outsize);
-    return Py_BuildValue("y#", out, outsize);
+    return Py_BuildValue(bytesFormat, out, outsize);
 }
 
 static PyObject *pyshoco_decompress(PyObject *self, PyObject *args) {
     const char *in;
     size_t insize;
 
-    if (!PyArg_ParseTuple(args, "y#", &in, &insize))
+    if (!PyArg_ParseTuple(args, bytesFormat, &in, &insize))
         return NULL;
     
     size_t outsize = insize*2+1;

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 
 if os.name == 'posix':
@@ -6,6 +6,17 @@ if os.name == 'posix':
 else:
     cflags = None
 
-pyshoco = Extension('pyshoco', sources = ['pyshoco.c', 'shoco.c'], include_dirs = ['.'], extra_compile_args = cflags)
+pyshoco = Extension(
+    'pyshoco',
+    sources=['pyshoco.c', 'shoco.c'],
+    include_dirs=['.'],
+    extra_compile_args=cflags)
 
-setup(name = 'pyshoco', version = '1.3.4', description = 'Shoco Python wrapper module', ext_modules = [pyshoco], author = 'R. Rowe', author_email = 'mega.gamer05@gmail.com', url = 'https://pypi.python.org/pypi/pyshoco/')
+setup(
+    name='pyshoco',
+    version='1.3.4',
+    description='Shoco Python wrapper module',
+    ext_modules=[pyshoco],
+    author='R. Rowe',
+    author_email='mega.gamer05@gmail.com',
+    url='https://pypi.python.org/pypi/pyshoco/')


### PR DESCRIPTION
The `pyshoco` library wasn't working for me with python3 due to some unicode decode errors. This fix makes the `compress` method return bytes and the `decompress` method take bytes as an input.

Interestingly, something else is up with the python3 setup in that it doesn't let you issue multiple calls to pyshoco functions from the same call stack. In other words, this will raise a seg fault:
```python
pyshoco.decompress(pyshoco.compress('matt'))
```
while this works fine:
```python
compressed = pyshoco.compress('matt')
pyshoco.decompress(compressed)
```

I assume it has something to do with shared memory in the same call stack but I'm not sure about that, haven't looked into it too much.